### PR TITLE
Fix intermediate reconcile resetting the requeue timer for next schedule

### DIFF
--- a/controllers/upgradeconfig_controller_test.go
+++ b/controllers/upgradeconfig_controller_test.go
@@ -88,6 +88,11 @@ func Test_UpgradeConfigReconciler_Reconcile_E2E(t *testing.T) {
 		require.NoError(t, err)
 		// In two weeks minus 1 day already advanced in previous step
 		require.Equal(t, (14*24*time.Hour)-(24*time.Hour), res.RequeueAfter)
+
+		clock.Advance(res.RequeueAfter - 7*time.Hour)
+		res, err = subject.Reconcile(ctx, requestForObject(upgradeConfig))
+		require.NoError(t, err)
+		require.Equal(t, 7*time.Hour, res.RequeueAfter, "intermediate requeue should not reset the requeue time")
 		clock.Advance(res.RequeueAfter)
 	})
 


### PR DESCRIPTION
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
