### PR TITLE
Fix crash on fresh, never upgraded cluster

### DIFF
--- a/pkg/clusterversion/clusterversion.go
+++ b/pkg/clusterversion/clusterversion.go
@@ -17,6 +17,10 @@ func SpecEqualIgnoringDesiredUpdate(a, b configv1.ClusterVersionSpec) (equal boo
 
 // IsVersionUpgradeCompleted returns whether the version upgrade in desired version is completed
 func IsVersionUpgradeCompleted(cv configv1.ClusterVersion) bool {
+	if cv.Spec.DesiredUpdate == nil {
+		return true
+	}
+
 	for _, version := range cv.Status.History {
 		if version.State == configv1.CompletedUpdate &&
 			version.Image == cv.Spec.DesiredUpdate.Image &&

--- a/pkg/clusterversion/clusterversion_test.go
+++ b/pkg/clusterversion/clusterversion_test.go
@@ -80,13 +80,12 @@ func TestIsVersionUpgradeCompleted(t *testing.T) {
 	desiredImg := "quay.io/openshift-release-dev/ocp-release@sha256:1234"
 	desiredVer := "4.5.23"
 
-	subject := configv1.ClusterVersion{
-		Spec: configv1.ClusterVersionSpec{
-			DesiredUpdate: &configv1.Update{
-				Image:   desiredImg,
-				Version: desiredVer,
-			},
-		},
+	subject := configv1.ClusterVersion{}
+	assert.True(t, clusterversion.IsVersionUpgradeCompleted(subject), "fresh install, desired update not set")
+
+	subject.Spec.DesiredUpdate = &configv1.Update{
+		Image:   desiredImg,
+		Version: desiredVer,
 	}
 	assert.False(t, clusterversion.IsVersionUpgradeCompleted(subject), "update not in history")
 


### PR DESCRIPTION
`DesiredUpdate` is nil on those clusters.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
