### PR TITLE
Allow marking `UpgradeJobHooks` disruptive

### DIFF
--- a/config/crd/bases/managedupgrade.appuio.io_upgradejobhooks.yaml
+++ b/config/crd/bases/managedupgrade.appuio.io_upgradejobhooks.yaml
@@ -34,6 +34,12 @@ spec:
           spec:
             description: UpgradeJobHookSpec defines the desired state of UpgradeJobHook
             properties:
+              disruptive:
+                description: Disruptive defines if the code run by the hook is potentially
+                  disruptive. Added to the job metrics and injected as an environment
+                  variable to all hooks matching the job. This is currently only informational,
+                  but can be used to make decisions in jobs. The default is `false`.
+                type: boolean
               events:
                 description: Events is the list of events to trigger the hook to be
                   executed. `Create`, `Start`, and `UpgradeComplete` are the events


### PR DESCRIPTION
## Summary

Fixes #37 

* Adds a new field to the `UpgradeJobHook` CRD `.spec.disruptive`
* Adds a new metric label to reflect if a job has disruptive hooks `matches_disruptive_hooks`.
  * Label changes are *breaking changes*.
* Adds an environment variable to all hook jobs/their containers if there is a disruptive hook job matching the current upgrade job `META_matchesDisruptiveHooks`.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
