### PR TITLE
Wait until `startAfter` before skipping upgrade job

### DIFF
--- a/controllers/upgradejob_controller_test.go
+++ b/controllers/upgradejob_controller_test.go
@@ -406,7 +406,14 @@ func Test_UpgradeJobReconciler_Reconcile_Skipped_Job(t *testing.T) {
 		ManagedUpstreamClusterVersionName: "version",
 	}
 
+	step(t, "startAfter not yet reached, should not skip job yet", func(t *testing.T) {
+		reconcileNTimes(t, subject, ctx, requestForObject(upgradeJob), 10)
+		require.Nil(t, apimeta.FindStatusCondition(upgradeJob.Status.Conditions, managedupgradev1beta1.UpgradeJobConditionSucceeded))
+	})
+
 	step(t, "Upgrade Skipped because of window", func(t *testing.T) {
+		// Move to start after time
+		clock.Advance(time.Hour)
 		reconcileNTimes(t, subject, ctx, requestForObject(upgradeJob), 10)
 		require.NoError(t, c.Get(ctx, requestForObject(upgradeJob).NamespacedName, upgradeJob))
 		sc := apimeta.FindStatusCondition(upgradeJob.Status.Conditions, managedupgradev1beta1.UpgradeJobConditionSucceeded)


### PR DESCRIPTION
## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
