### PR TITLE
Fix race condition when unpausing MCP at the end of a noop-for-pool maintenance

### DIFF
--- a/controllers/upgradejob_controller_test.go
+++ b/controllers/upgradejob_controller_test.go
@@ -168,7 +168,7 @@ func Test_UpgradeJobReconciler_Reconcile_E2E_Upgrade(t *testing.T) {
 		_, err := subject.Reconcile(ctx, requestForObject(upgradeJob))
 		require.NoError(t, err)
 		require.NoError(t, c.Get(ctx, requestForObject(ucv).NamespacedName, ucv))
-		lock, ok := ucv.Annotations[ClusterVersionLockAnnotation]
+		lock, ok := ucv.Annotations[JobLockAnnotation]
 		require.True(t, ok, "lock annotation must be set")
 		require.Equal(t, upgradeJob.Namespace+"/"+upgradeJob.Name, lock, "lock annotation must contain upgrade job reference")
 	})
@@ -295,7 +295,7 @@ func Test_UpgradeJobReconciler_Reconcile_E2E_Upgrade(t *testing.T) {
 		_, err = subject.Reconcile(ctx, requestForObject(upgradeJob))
 		require.NoError(t, err)
 		require.NoError(t, c.Get(ctx, requestForObject(ucv).NamespacedName, ucv))
-		require.Empty(t, ucv.Annotations[ClusterVersionLockAnnotation], "should clear lock annotation")
+		require.Empty(t, ucv.Annotations[JobLockAnnotation], "should clear lock annotation")
 		_, err = subject.Reconcile(ctx, requestForObject(upgradeJob))
 		require.NoError(t, err, "should ignore requests if cluster version is not locked")
 	})
@@ -425,7 +425,7 @@ func Test_UpgradeJobReconciler_Reconcile_Skipped_Job(t *testing.T) {
 
 		require.NoError(t, c.Get(ctx, requestForObject(ucv).NamespacedName, ucv))
 		require.Empty(t, ucv.Spec.DesiredUpdate, "cluster version should not be updated")
-		require.Empty(t, ucv.Annotations[ClusterVersionLockAnnotation], "cluster version should not be locked")
+		require.Empty(t, ucv.Annotations[JobLockAnnotation], "cluster version should not be locked")
 	})
 
 	step(t, "`Success` and `Finish` hooks", func(t *testing.T) {
@@ -969,7 +969,7 @@ func Test_UpgradeJobReconciler_Reconcile_UpgradeWithdrawn(t *testing.T) {
 	require.NotNil(t, failedCond, "should set failed condition")
 	require.Equal(t, managedupgradev1beta1.UpgradeJobReasonUpgradeWithdrawn, failedCond.Reason)
 	require.NoError(t, client.Get(ctx, requestForObject(ucv).NamespacedName, ucv))
-	require.Empty(t, ucv.Annotations[ClusterVersionLockAnnotation], "should clear lock annotation")
+	require.Empty(t, ucv.Annotations[JobLockAnnotation], "should clear lock annotation")
 }
 
 func Test_UpgradeJobReconciler_Reconcile_Timeout(t *testing.T) {
@@ -1024,7 +1024,7 @@ func Test_UpgradeJobReconciler_Reconcile_Timeout(t *testing.T) {
 	require.NotNil(t, failedCond, "should set failed condition")
 	require.Equal(t, managedupgradev1beta1.UpgradeJobReasonTimedOut, failedCond.Reason)
 	require.NoError(t, client.Get(ctx, requestForObject(ucv).NamespacedName, ucv))
-	require.Empty(t, ucv.Annotations[ClusterVersionLockAnnotation], "should clear lock annotation")
+	require.Empty(t, ucv.Annotations[JobLockAnnotation], "should clear lock annotation")
 }
 
 func Test_UpgradeJobReconciler_Reconcile_PreHealthCheckTimeout(t *testing.T) {
@@ -1088,7 +1088,7 @@ func Test_UpgradeJobReconciler_Reconcile_PreHealthCheckTimeout(t *testing.T) {
 	require.NotNil(t, failedCond, "should set failed condition")
 	require.Equal(t, managedupgradev1beta1.UpgradeJobReasonPreHealthCheckFailed, failedCond.Reason)
 	require.NoError(t, client.Get(ctx, requestForObject(ucv).NamespacedName, ucv))
-	require.Empty(t, ucv.Annotations[ClusterVersionLockAnnotation], "should clear lock annotation")
+	require.Empty(t, ucv.Annotations[JobLockAnnotation], "should clear lock annotation")
 }
 
 func Test_UpgradeJobReconciler_Reconcile_PostHealthCheckTimeout(t *testing.T) {
@@ -1161,7 +1161,7 @@ func Test_UpgradeJobReconciler_Reconcile_PostHealthCheckTimeout(t *testing.T) {
 	require.NotNil(t, failedCond, "should set failed condition")
 	require.Equal(t, managedupgradev1beta1.UpgradeJobReasonPostHealthCheckFailed, failedCond.Reason)
 	require.NoError(t, client.Get(ctx, requestForObject(ucv).NamespacedName, ucv))
-	require.Empty(t, ucv.Annotations[ClusterVersionLockAnnotation], "should clear lock annotation")
+	require.Empty(t, ucv.Annotations[JobLockAnnotation], "should clear lock annotation")
 }
 
 func Test_UpgradeJobReconciler_Reconcile_PausedMachineConfigPools(t *testing.T) {
@@ -1544,7 +1544,7 @@ func Test_JobFromClusterVersionHandler(t *testing.T) {
 	require.Len(t, subject(context.Background(), nil), 0, "should not return a reconcile request if clusterversion is not locked")
 
 	ucv.Annotations = map[string]string{
-		ClusterVersionLockAnnotation: "ns/upgrade-1234-4-5-13",
+		JobLockAnnotation: "ns/upgrade-1234-4-5-13",
 	}
 	require.NoError(t, client.Update(context.Background(), ucv))
 


### PR DESCRIPTION
The previous version was able to get into an invalid state: the upgrade job was updated twice ([1][1], [2][2]) at the end of an update and the k8s client cache does not guarantee read after write consistency [3][3]. This lead to the MCPs being paused again just after force unpausing them.

[1]: https://github.com/appuio/openshift-upgrade-controller/blob/0c1b407fd99a17ada4242a6454303911938377cd/controllers/upgradejob_controller.go#L939
[2]: https://github.com/appuio/openshift-upgrade-controller/blob/0c1b407fd99a17ada4242a6454303911938377cd/controllers/upgradejob_controller.go#L334
[3]: https://pkg.go.dev/sigs.k8s.io/controller-runtime#hdr-Clients_and_Caches

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
