### PR TITLE
Allow cleanup of successful jobs

### DIFF
--- a/api/v1beta1/upgradeconfig_types.go
+++ b/api/v1beta1/upgradeconfig_types.go
@@ -24,9 +24,23 @@ type UpgradeConfigSpec struct {
 	// +kubebuilder:validation:Format=duration
 	// +kubebuilder:default:="1h"
 	MaxUpgradeStartDelay metav1.Duration `json:"maxUpgradeStartDelay"`
+	// SuccessfulJobsHistoryLimit is the number of successful jobs to keep.
+	// A value smaller or equal to zero indicates no limit.
+	// It is not possible to remove the most recent job.
+	// Defaults to 4 if not set.
+	// +optional
+	SuccessfulJobsHistoryLimit *int `json:"successfulJobsHistoryLimit,omitempty"`
 
 	// JobTemplate defines the template for the upgrade job
 	JobTemplate UpgradeConfigJobTemplate `json:"jobTemplate"`
+}
+
+// GetSuccessfulJobsHistoryLimit returns the number of successful jobs to keep. Defaults to 3 if not set.
+func (in UpgradeConfigSpec) GetSuccessfulJobsHistoryLimit() int {
+	if in.SuccessfulJobsHistoryLimit == nil {
+		return 4
+	}
+	return *in.SuccessfulJobsHistoryLimit
 }
 
 // UpgradeConfigJobTemplate defines the desired state of UpgradeJob

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -393,6 +393,11 @@ func (in *UpgradeConfigSpec) DeepCopyInto(out *UpgradeConfigSpec) {
 	out.PinVersionWindow = in.PinVersionWindow
 	out.MaxSchedulingDelay = in.MaxSchedulingDelay
 	out.MaxUpgradeStartDelay = in.MaxUpgradeStartDelay
+	if in.SuccessfulJobsHistoryLimit != nil {
+		in, out := &in.SuccessfulJobsHistoryLimit, &out.SuccessfulJobsHistoryLimit
+		*out = new(int)
+		**out = **in
+	}
 	in.JobTemplate.DeepCopyInto(&out.JobTemplate)
 }
 

--- a/config/crd/bases/managedupgrade.appuio.io_upgradeconfigs.yaml
+++ b/config/crd/bases/managedupgrade.appuio.io_upgradeconfigs.yaml
@@ -244,6 +244,13 @@ spec:
                 - cron
                 - location
                 type: object
+              successfulJobsHistoryLimit:
+                description: |-
+                  SuccessfulJobsHistoryLimit is the number of successful jobs to keep.
+                  A value smaller or equal to zero indicates no limit.
+                  It is not possible to remove the most recent job.
+                  Defaults to 4 if not set.
+                type: integer
             required:
             - jobTemplate
             - maxSchedulingDelay


### PR DESCRIPTION
Allows cleanup of older successful jobs.

Defaults to `4`, roughly one month if updating weekly.

Adds `successfulJobsHistoryLimit` to `UpgradeConfig` spec. I did not add the same field for failed jobs since they need to be cleaned up manually anyways. It is not possible by design to delete the most recent successful job.

Fixes #118.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
