### PR TITLE
Remove error on missing drain annotation

### DIFF
--- a/controllers/node_controller_test.go
+++ b/controllers/node_controller_test.go
@@ -39,15 +39,6 @@ func Test_NodeReconciler_Reconcile(t *testing.T) {
 	_, err = subject.Reconcile(ctx, requestFor("node1"))
 	require.NoError(t, err)
 	compareMetrics(t, "node1", 1.0, "node should be draining if desired drainer is different from last applied drainer annotation")
-
-	n := node("node1", "", "")
-	n.Annotations = map[string]string{}
-	require.NoError(t, client.Update(ctx, n))
-	_, err = subject.Reconcile(ctx, requestFor("node1"))
-	require.NoError(t, err)
-	require.Equal(t, 0,
-		testutil.CollectAndCount(nodeDraining, "openshift_upgrade_controller_node_draining"),
-		"metric should be removed if not able to calculate it")
 }
 
 func compareMetrics(t *testing.T, nodeLbl string, expected float64, msgAndArgs ...interface{}) {

--- a/controllers/node_force_drain_controller.go
+++ b/controllers/node_force_drain_controller.go
@@ -93,13 +93,8 @@ func (r *NodeForceDrainReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	// Check for draining nodes, using the node drainer annotations.
 	drainingNodes := make([]corev1.Node, 0, len(nodes.Items))
 	for _, node := range nodes.Items {
-		l := l.WithValues("node", node.Name)
-		desiredDrain, ddOk := node.Annotations[DesiredDrainerAnnotationKey]
-		lastAppliedDrain, laOk := node.Annotations[LastAppliedDrainerAnnotationKey]
-		if !ddOk || !laOk {
-			l.Info("Node is missing drain annotations. Not OCP?", "desiredDrain", desiredDrain, "lastAppliedDrain", lastAppliedDrain)
-			continue
-		}
+		desiredDrain := node.Annotations[DesiredDrainerAnnotationKey]
+		lastAppliedDrain := node.Annotations[LastAppliedDrainerAnnotationKey]
 		if desiredDrain == lastAppliedDrain {
 			continue
 		}


### PR DESCRIPTION
New nodes might miss one or both annotations.
We had a warning in place because the code was originally for a more generalized controller. Because nodes were pretty static so far this was never an issue; now with autoscaling we have many more new nodes.


## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
