### PR TITLE
Force delete pod with grace period of `1`

### DIFF
--- a/controllers/node_force_drain_controller.go
+++ b/controllers/node_force_drain_controller.go
@@ -289,7 +289,12 @@ func (r *NodeForceDrainReconciler) forceDeletePodsOnNode(ctx context.Context, no
 
 		l.Info("Force deleting pod")
 		if err := r.Delete(ctx, &pod, &client.DeleteOptions{
-			GracePeriodSeconds: ptr.To(int64(0)),
+			// As far is I was able to find a grace period of 0 will leave the hanging pod on the node and block the reboot of the node.
+			// Therefore we set a grace period of 1 second for the quickest possible deletion.
+			// See kubectl delete docs:
+			// https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#delete
+			// > Period of time in seconds given to the resource to terminate gracefully. [...] Set to 1 for immediate shutdown. Can only be set to 0 when --force is true (force deletion).
+			GracePeriodSeconds: ptr.To(int64(1)),
 		}); err != nil {
 			deletionErrs = append(deletionErrs, err)
 		}

--- a/controllers/upgradejob_controller_test.go
+++ b/controllers/upgradejob_controller_test.go
@@ -1623,7 +1623,7 @@ func stuckPodSimulator(ctx context.Context, cli client.WithWatch, obj client.Obj
 		opt.ApplyToDelete(&delOpts)
 	}
 	_, isPod := obj.(*corev1.Pod)
-	if isPod && delOpts.GracePeriodSeconds != nil && *delOpts.GracePeriodSeconds == 0 {
+	if isPod && delOpts.GracePeriodSeconds != nil && (*delOpts.GracePeriodSeconds == 0 || *delOpts.GracePeriodSeconds == 1) {
 		var pod corev1.Pod
 		if err := cli.Get(ctx, client.ObjectKeyFromObject(obj), &pod); err != nil {
 			return fmt.Errorf("failed to get pod to remove finalizer: %w", err)


### PR DESCRIPTION
As far is I was able to find a grace period of 0 will leave the hanging pod on the node and block the reboot of the node.
Therefore we set a grace period of 1 second for the quickest possible deletion.

See kubectl delete docs:
> Period of time in seconds given to the resource to terminate gracefully. [...] Set to 1 for immediate shutdown. Can only be set to 0 when --force is true (force deletion).
- https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#delete

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
