### PR TITLE
Fix parsing of some flags

### DIFF
--- a/main.go
+++ b/main.go
@@ -72,7 +72,6 @@ func main() {
 		Development: true,
 	}
 	opts.BindFlags(flag.CommandLine)
-	flag.Parse()
 
 	defaultNamespace := "default"
 	if ns := os.Getenv("POD_NAMESPACE"); ns != "" {
@@ -90,6 +89,8 @@ func main() {
 
 	var machineNamespace string
 	flag.StringVar(&machineNamespace, "machine-namespace", "openshift-machine-api", "The namespace where the machines are located.")
+
+	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 


### PR DESCRIPTION
`flag.Parse()` was called before all flags were defined.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
