### PR TITLE
Allow disabling version availability check at the start of the upgrade

### DIFF
--- a/api/v1beta1/upgradejob_types.go
+++ b/api/v1beta1/upgradejob_types.go
@@ -72,8 +72,24 @@ type UpgradeJobSpec struct {
 	// +optional
 	DesiredVersion *configv1.Update `json:"desiredVersion,omitempty"`
 
+	// DesiredVersionCheckAvailability defines whether to check if the desired version is available at the start of the upgrade.
+	// This is done by searching the ClusterVersion status for the desired version.
+	// If set to true, the upgrade job will fail with reason UpgradeJobReasonUpgradeWithdrawn if the desired version is not available.
+	// If set to false, the upgrade job will not check for the availability of the desired version and will apply the DesiredVersion directly.
+	// Defaults to true.
+	// +optional
+	DesiredVersionCheckAvailability *bool `json:"desiredVersionCheckAvailability,omitempty"`
+
 	// UpgradeJobConfig defines the configuration for the upgrade job
 	UpgradeJobConfig `json:"config"`
+}
+
+// GetDesiredVersionCheckAvailability returns DesiredVersionCheckAvailability with a default value of true if nil.
+func (s UpgradeJobSpec) GetDesiredVersionCheckAvailability() bool {
+	if s.DesiredVersionCheckAvailability == nil {
+		return true
+	}
+	return *s.DesiredVersionCheckAvailability
 }
 
 // UpgradeJobConfig defines the configuration for the upgrade job

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -801,6 +801,11 @@ func (in *UpgradeJobSpec) DeepCopyInto(out *UpgradeJobSpec) {
 		*out = new(configv1.Update)
 		**out = **in
 	}
+	if in.DesiredVersionCheckAvailability != nil {
+		in, out := &in.DesiredVersionCheckAvailability, &out.DesiredVersionCheckAvailability
+		*out = new(bool)
+		**out = **in
+	}
 	in.UpgradeJobConfig.DeepCopyInto(&out.UpgradeJobConfig)
 }
 

--- a/config/crd/bases/managedupgrade.appuio.io_upgradejobs.yaml
+++ b/config/crd/bases/managedupgrade.appuio.io_upgradejobs.yaml
@@ -214,6 +214,14 @@ spec:
                 - message: Version must be set if Architecture is set
                   rule: 'has(self.architecture) && self.architecture != '''' ? self.version
                     != '''' : true'
+              desiredVersionCheckAvailability:
+                description: |-
+                  DesiredVersionCheckAvailability defines whether to check if the desired version is available at the start of the upgrade.
+                  This is done by searching the ClusterVersion status for the desired version.
+                  If set to true, the upgrade job will fail with reason UpgradeJobReasonUpgradeWithdrawn if the desired version is not available.
+                  If set to false, the upgrade job will not check for the availability of the desired version and will apply the DesiredVersion directly.
+                  Defaults to true.
+                type: boolean
               startAfter:
                 description: StartAfter defines the time after which the upgrade job
                   should start

--- a/controllers/upgradejob_controller.go
+++ b/controllers/upgradejob_controller.go
@@ -226,8 +226,8 @@ func (r *UpgradeJobReconciler) reconcileStartedJob(ctx context.Context, uj *mana
 	if uj.Spec.DesiredVersion != nil {
 		// Check if the desired version is already set
 		if version.Spec.DesiredUpdate == nil || *version.Spec.DesiredUpdate != *uj.Spec.DesiredVersion {
-			update := clusterversion.FindAvailableUpdate(version, uj.Spec.DesiredVersion.Image, uj.Spec.DesiredVersion.Version)
-			if update == nil {
+			if uj.Spec.GetDesiredVersionCheckAvailability() &&
+				clusterversion.FindAvailableUpdate(version, uj.Spec.DesiredVersion.Image, uj.Spec.DesiredVersion.Version) == nil {
 				r.setStatusCondition(&uj.Status.Conditions, metav1.Condition{
 					Type:    managedupgradev1beta1.UpgradeJobConditionFailed,
 					Status:  metav1.ConditionTrue,


### PR DESCRIPTION
Adds a new field `.spec.desiredVersionCheckAvailability`, defaulting to true, to the `UpgradeJob` definition.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
