### PR TITLE
Fix force drain active daemonset check 

### DIFF
--- a/controllers/node_force_drain_controller.go
+++ b/controllers/node_force_drain_controller.go
@@ -499,7 +499,7 @@ func (r *NodeForceDrainReconciler) podIsControlledByExistingDaemonSet(ctx contex
 	// We don't need a full object, metadata is enough.
 	var ds metav1.PartialObjectMetadata
 	ds.SetGroupVersionKind(appsv1.SchemeGroupVersion.WithKind("DaemonSet"))
-	err := r.Get(ctx, client.ObjectKey{Namespace: pod.Namespace, Name: controllerRef.Name}, &ds)
+	err := r.APIReader.Get(ctx, client.ObjectKey{Namespace: pod.Namespace, Name: controllerRef.Name}, &ds)
 	if err != nil {
 		// Edge case: Pod was orphaned
 		// See https://github.com/kubernetes/kubectl/blob/442e3d141a35703b7637f41339b9f73cad005c47/pkg/drain/filters.go#L174

--- a/main.go
+++ b/main.go
@@ -172,7 +172,7 @@ func main() {
 	}
 	if namespace != "" {
 		cacheOpts.DefaultNamespaces = map[string]cache.Config{
-			defaultNamespace: {},
+			namespace: {},
 		}
 	}
 
@@ -294,7 +294,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	setupLog.Info("starting manager")
+	setupLog.Info("starting manager", "namespace", namespace)
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)


### PR DESCRIPTION
The cache is constrained to the controller namespace by default. We could expand the cache for daemonsets but we don't want to cache all daemonsets for a few requests a maintenance.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
