### PR TITLE
Use only immutable dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,8 @@ on:
     branches:
       - master
 
+permissions: {}
+
 jobs:
   go:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,6 +3,8 @@ name: Lint
 on:
   pull_request: {}
 
+permissions: {}
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,49 +5,14 @@ on:
     tags:
       - "*"
 
+permissions: {}
+
 jobs:
-  goreleaser:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: 'go.mod'
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Login to ghcr.io
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build changelog from PRs with labels
-        id: build_changelog
-        uses: mikepenz/release-changelog-builder-action@v6
-        with:
-          configuration: ".github/changelog-configuration.json"
-          # PreReleases still get a changelog, but the next full release gets a diff since the last full release,
-          # combining possible changelogs of all previous PreReleases in between.
-          # PreReleases show a partial changelog since last PreRelease.
-          ignorePreReleases: "${{ !contains(github.ref, '-rc') }}"
-          outputFile: .github/release-notes.md
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Publish releases
-        uses: goreleaser/goreleaser-action@v7
-        with:
-          args: release --release-notes .github/release-notes.md
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REGISTRY: ghcr.io
-          IMAGE_NAME: ${{ github.repository }}
+  release:
+    name: Release
+    uses: ./.github/workflows/tooling-release.yml
+    permissions:
+      contents: write # Required to publish a release
+      packages: write # Required to push the docker images
+    with:
+      goreleaser-version: "2.16.0"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,8 @@ on:
     branches:
       - master
 
+permissions: {}
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/tooling-release.yml
+++ b/.github/workflows/tooling-release.yml
@@ -1,0 +1,57 @@
+name: Tooling Release
+
+on:
+  workflow_call:
+    inputs:
+      goreleaser-version:
+        description: The version of GoReleaser to use for builds and releases.
+        required: true
+        type: string
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to ghcr.io
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build changelog from PRs with labels
+        id: build_changelog
+        uses: mikepenz/release-changelog-builder-action@v6
+        with:
+          configuration: ".github/changelog-configuration.json"
+          # PreReleases still get a changelog, but the next full release gets a diff since the last full release,
+          # combining possible changelogs of all previous PreReleases in between.
+          # PreReleases show a partial changelog since last PreRelease.
+          ignorePreReleases: "${{ !contains(github.ref, '-rc') }}"
+          outputFile: .github/release-notes.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish releases
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          version: "${{ inputs.goreleaser-version }}"
+          args: release --release-notes .github/release-notes.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REGISTRY: ghcr.io
+          IMAGE_NAME: ${{ github.repository }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,4 @@
-FROM docker.io/library/alpine:3.23 as runtime
+FROM gcr.io/distroless/static:nonroot
 
-RUN \
-  apk add --update --no-cache \
-    bash \
-    curl \
-    ca-certificates \
-    tzdata
-
-ENTRYPOINT ["openshift-upgrade-controller"]
+ENTRYPOINT ["/usr/bin/openshift-upgrade-controller"]
 COPY openshift-upgrade-controller /usr/bin/
-
-USER 65536:0

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,9 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    ":gitSignOff"
+    ":gitSignOff",
+    "helpers:pinGitHubActionDigests",
+    "docker:pinDigests"
   ],
   "labels": [
     "dependency"
@@ -24,7 +26,22 @@
     },
     {
       "matchManagers": ["github-actions"],
-      "groupName": "github actions dependencies"
+      "groupName": "github actions dependencies",
+      "minimumReleaseAge": "7 days",
+      "prCreation": "not-pending",
+      "internalChecksFilter": "strict"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/\\.github/workflows/.+\\.yml$/"
+      ],
+      "matchStrings": [
+        "goreleaser-version:\\s+[\"']?(?<currentValue>v?[0-9.]+)[\"']?"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "goreleaser/goreleaser",
+      "versioningTemplate": "semver"
     }
   ]
 }


### PR DESCRIPTION
Goreleaser is only promised immutable, all actions and the docker image should be pinned by renovate as soon as this is merged to master.

We could in theory to `go get -tool ...goreleaser` but i'm not sure if it's worth the additional compile time and renovate trying to renovate go dependencies chaos.

https://goreleaser.com/blog/immutable-releases/

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
