### PR TITLE
Fix controller not timeouting on start hook failure

### DIFF
--- a/controllers/upgradejob_controller.go
+++ b/controllers/upgradejob_controller.go
@@ -179,14 +179,6 @@ func (r *UpgradeJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 func (r *UpgradeJobReconciler) reconcileStartedJob(ctx context.Context, uj *managedupgradev1beta1.UpgradeJob) (ctrl.Result, error) {
 	l := log.FromContext(ctx).WithName("UpgradeJobReconciler.reconcileStartedJob")
 
-	cont, err := r.executeHooks(ctx, uj, managedupgradev1beta1.EventStart, noTrackingKey, eventInfoWithReason(managedupgradev1beta1.UpgradeJobReasonStarted), time.Time{})
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-	if !cont {
-		return ctrl.Result{}, nil
-	}
-
 	if r.timeSinceStartAfter(uj) > uj.Spec.UpgradeTimeout.Duration {
 		r.setStatusCondition(&uj.Status.Conditions, metav1.Condition{
 			Type:    managedupgradev1beta1.UpgradeJobConditionFailed,
@@ -195,6 +187,14 @@ func (r *UpgradeJobReconciler) reconcileStartedJob(ctx context.Context, uj *mana
 			Message: fmt.Sprintf("Upgrade timed out after %s", uj.Spec.UpgradeTimeout.Duration.String()),
 		})
 		return ctrl.Result{}, r.Status().Update(ctx, uj)
+	}
+
+	cont, err := r.executeHooks(ctx, uj, managedupgradev1beta1.EventStart, noTrackingKey, eventInfoWithReason(managedupgradev1beta1.UpgradeJobReasonStarted), time.Time{})
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if !cont {
+		return ctrl.Result{}, nil
 	}
 
 	var version configv1.ClusterVersion


### PR DESCRIPTION
Not sure why the check order was wrong in the first place. Timeout condition is now checked *before* checking start job execution.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
